### PR TITLE
Adiciona data-article como tipo citavel

### DIFF
--- a/publicationstats/utils.py
+++ b/publicationstats/utils.py
@@ -4,6 +4,7 @@ CITABLE_DOCUMENT_TYPES = (
     u'article-commentary',
     u'brief-report',
     u'case-report',
+    u'data-article',
     u'rapid-communication',
     u'research-article',
     u'review-article'


### PR DESCRIPTION
Este PR considera o tipo de documento 'data-article' como citável.

**Onde a revisão poderia começar?**
https://github.com/scieloorg/publicationstatsapi/blob/master/publicationstats/utils.py#L3

**Quais são tickets relevantes?**
#4 e https://github.com/scieloorg/articles_meta/issues/183